### PR TITLE
Fix bug: Hide correct answer message when user gets answer right

### DIFF
--- a/numbers/app.js
+++ b/numbers/app.js
@@ -205,6 +205,7 @@
       // Correct answer
       feedback.className = "correct";
       feedbackText.textContent = "✓ Correct!";
+      correctAnswer.classList.add("hidden"); // Hide correct answer for correct responses
       currentStreak++;
       totalCorrect++;
       


### PR DESCRIPTION
- Added correctAnswer.classList.add('hidden') for correct responses
- Previously the 'correct answer' message was showing even for correct answers
- Now only shows the correct answer when the user gets it wrong